### PR TITLE
Add offline dataset training support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# KOFBot
+
+This repository contains utilities for training a Rainbow RDQN agent for *The King of Fighters 2002 UM* using [RLlib](https://docs.ray.io/en/latest/rllib.html).
+
+## Recording gameplay
+
+You can create an offline training dataset by recording gameplay or an existing agent using RLlib's rollout tool:
+
+```bash
+rllib rollout <checkpoint_path> --algo DQN --episodes 10 --out offline_data
+```
+
+This writes JSON files under `offline_data/` that can later be used for offline learning.
+
+## Training
+
+Run `train.py` directly for online training or pass the path to a dataset for offline training:
+
+```bash
+# Online (default)
+python train.py
+
+# Offline
+python train.py --offline-dataset offline_data
+```
+
+The script will automatically switch to offline mode when the dataset path is provided.

--- a/train.py
+++ b/train.py
@@ -103,6 +103,18 @@ if __name__ == "__main__":
     parser.add_argument("--stop-iters", type=int, default=30_000)
     parser.add_argument("--stop-timesteps", type=int, default=3_000_000)
     parser.add_argument("--stop-reward", type=float, default=350.0)
+    parser.add_argument(
+        "--offline-dataset",
+        type=str,
+        default=None,
+        help="Path to an offline dataset (JSON format). If provided, training is offline.",
+    )
+    parser.add_argument(
+        "--dataset-format",
+        type=str,
+        default="json",
+        help="Format of the offline dataset if --offline-dataset is set.",
+    )
     args = parser.parse_args()
 
     p = Process(target=plot_worker, args=(shared_action_counts, plot_stop_event), daemon=True)
@@ -110,6 +122,14 @@ if __name__ == "__main__":
 
     ray.init(ignore_reinit_error=True)
     config = get_rainbow_rdqn_config()
+
+    if args.offline_dataset:
+        config["input"] = args.offline_dataset
+        config["input_config"] = {"format": args.dataset_format}
+        print(f"Training offline using dataset: {args.offline_dataset}")
+    else:
+        config["input"] = "sampler"
+
     trainer = DQN(config=config)
 
     for i in range(args.stop_iters):


### PR DESCRIPTION
## Summary
- add `--offline-dataset` and `--dataset-format` args
- configure RLlib to load data from file when provided
- document how to record gameplay and train from a dataset

## Testing
- `python -m py_compile train.py env.py wrappers.py kofbot.py`

------
https://chatgpt.com/codex/tasks/task_e_684a149a77388329ace4c1e3a84ea0a1