### PR TITLE
Add step logging to KOFEnv

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# KofBot
+
+This repository contains utilities and environments for training agents in **King of Fighters 2002 UM**.
+
+## Logging Episodes
+
+`KOFEnv` can optionally record every transition.  Pass a path when creating the environment:
+
+```python
+from env import KOFEnv
+env = KOFEnv(record_path="episode_log.jsonl")
+```
+
+Each call to `reset()` or `step()` will append a JSON line with the keys `"obs"`, `"action"`, `"reward"`, `"next_obs"`, and `"done"`.  Call `env.flush_log()` or `env.close_log()` after an episode to make sure the data is written to disk.


### PR DESCRIPTION
## Summary
- optionally log transitions in `KOFEnv`
- write JSON lines during `reset()` and `step()` when `record_path` is set
- add `flush_log()`/`close_log()` helpers
- document the option in a new README

## Testing
- `python -m py_compile env.py wrappers.py train.py kofbot.py`

------
https://chatgpt.com/codex/tasks/task_e_684a1498d63c8329ad9945f4ac11e714