### PR TITLE
Default dataset directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,15 +14,20 @@ This writes JSON files under `offline_data/` that can later be used for offline 
 
 ## Training
 
-Run `train.py` directly for online training or pass the path to a dataset for offline training:
+`train.py` can operate in either online or offline mode. You can explicitly set
+the mode using the `--mode` flag or leave it off and choose interactively at
+startup:
 
 ```bash
-# Online (default)
-python train.py
+# Online
+python train.py --mode online
 
 # Offline
-python train.py --offline-dataset offline_data
+python train.py --mode offline --offline-dataset offline_data
 ```
 
-The script will automatically switch to offline mode when the dataset path is provided.
+If `--mode` is not given, `train.py` prompts you to pick a mode. When
+selecting offline mode you can specify a dataset path or leave it blank. If you
+leave it blank, a `dataset/` folder will be created next to `train.py` and used
+as the dataset location.
 


### PR DESCRIPTION
## Summary
- prompt for an offline dataset path but allow it to be blank
- create a `dataset/` folder next to `train.py` when no path is given
- document the new default directory in the README

## Testing
- `python -m py_compile train.py`
- `python train.py --help` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_684a1d28a85883298f210f35760319c2