### PR TITLE
Fix deprecated prioritized replay config

### DIFF
--- a/train.py
+++ b/train.py
@@ -49,10 +49,13 @@ def get_rainbow_rdqn_config():
         "lr": 1e-4,
         "gamma": 0.99,
         "double_q": True,
-        "prioritized_replay": True,
-        "prioritized_replay_alpha": 0.6,
-        "prioritized_replay_beta": 0.4,
-        "prioritized_replay_eps": 1e-6,
+        # Use prioritized replay buffer via new replay_buffer_config API.
+        "replay_buffer_config": {
+            "type": "MultiAgentPrioritizedReplayBuffer",
+            "prioritized_replay_alpha": 0.6,
+            "prioritized_replay_beta": 0.4,
+            "prioritized_replay_eps": 1e-6,
+        },
     }
 
 


### PR DESCRIPTION
## Summary
- modernize replay buffer config for DQN

## Testing
- `python -m py_compile env.py kofbot.py train.py wrappers.py`

------
https://chatgpt.com/codex/tasks/task_e_684a20244c1c83299f4164df2556a291