### PR TITLE
Add multi-instance game launch control

### DIFF
--- a/train.py
+++ b/train.py
@@ -12,7 +12,12 @@ import argparse
 def kof_rainbow_env_creator(env_config: EnvContext):
     frame_skip = env_config.get("frame_skip", 1)
     base_env_cls = env_config["base_env_cls"]
-    return KOFActionRepeatEnv(base_env_cls, frame_skip=frame_skip)
+    base_env_kwargs = env_config.get("base_env_kwargs", {})
+
+    def factory():
+        return base_env_cls(**base_env_kwargs)
+
+    return KOFActionRepeatEnv(factory, frame_skip=frame_skip)
 
 register_env("KOF-RDQN-v0", kof_rainbow_env_creator)
 
@@ -23,8 +28,13 @@ def get_rainbow_rdqn_config():
         "env_config": {
             "base_env_cls": KOFEnv,
             "frame_skip": 1,
+            "base_env_kwargs": {
+                "game_exe_path": None,
+                "launch_game": False,
+                "auto_start": True,
+            },
         },
-        "num_workers": 0,
+        "num_workers": 1,
         "num_gpus": 0,
         "framework": "torch",
         "batch_mode": "complete_episodes",

--- a/wrappers.py
+++ b/wrappers.py
@@ -10,10 +10,10 @@ class KOFActionRepeatEnv(Env):
     by “repeating” each chosen button press for exactly `frame_skip` internal ticks of KOFEnv.
     Also collapses the 5‐tuple (obs, rew, done, truncated, info) into (obs, rew, done, info).
     """
-    def __init__(self, base_env_cls, frame_skip: int = 1):
+    def __init__(self, base_env_factory, frame_skip: int = 1):
         """
         Args:
-            base_env_cls: a zero-argument callable that returns your original KOFEnv()
+            base_env_factory: callable that returns a configured ``KOFEnv`` instance
             frame_skip: how many emulator ticks to hold each button before asking agent again
         """
         super().__init__()
@@ -23,7 +23,7 @@ class KOFActionRepeatEnv(Env):
 
         log("Creating base environment")
         # Instantiate the underlying KOFEnv
-        self.orig_env: KOFEnv = base_env_cls()
+        self.orig_env: KOFEnv = base_env_factory()
         log("Base environment created")
 
         # Ensure original action_space is MultiDiscrete([n_buttons, max_hold])


### PR DESCRIPTION
## Summary
- allow `KOFEnv` to optionally launch a game executable and skip menu automation
- support passing kwargs to `KOFEnv` via `KOFActionRepeatEnv`
- expose `base_env_kwargs` and enable multiple workers in the training config

## Testing
- `python -m py_compile env.py wrappers.py train.py`

------
https://chatgpt.com/codex/tasks/task_e_684f482a47ec8329976f21d6caba81f0