### PR TITLE
Support both Discrete and MultiDiscrete action spaces

### DIFF
--- a/wrappers.py
+++ b/wrappers.py
@@ -1,13 +1,17 @@
 import numpy as np
 from gymnasium import Env
 from gymnasium.spaces import Discrete, MultiDiscrete
-from env import KOFEnv, action_map
+from env import KOFEnv
 
 class KOFActionRepeatEnv(Env):
-    """
-    Wraps your original KOFEnv (MultiDiscrete space) into a Discrete(n_buttons) environment
-    by “repeating” each chosen button press for exactly `frame_skip` internal ticks of KOFEnv.
-    Also collapses the 5‐tuple (obs, rew, done, truncated, info) into (obs, rew, done, info).
+    """Wrap a :class:`KOFEnv` so agents see a simple ``Discrete`` action space.
+
+    Each chosen button press is repeated for ``frame_skip`` internal ticks of the
+    underlying environment.  The wrapper works with both the original
+    ``MultiDiscrete`` action space as well as newer ``Discrete`` versions.
+
+    It also converts 4-tuples returned by older envs into the 5-value tuple
+    expected by Gymnasium.
     """
     def __init__(self, base_env_factory, frame_skip: int = 1):
         """
@@ -25,10 +29,21 @@ class KOFActionRepeatEnv(Env):
         self.orig_env: KOFEnv = base_env_factory()
         log("Base environment created")
 
-        # Ensure original action_space is MultiDiscrete([n_buttons, max_hold])
-        assert isinstance(self.orig_env.action_space, MultiDiscrete), \
-            "KOFEnv.action_space must be MultiDiscrete([n_buttons, max_hold])"
-        self.num_buttons = int(self.orig_env.action_space.nvec[0])
+        # Determine whether the base env expects a MultiDiscrete or Discrete
+        # action. Older versions of :class:`KOFEnv` used ``MultiDiscrete`` where
+        # the first element was the button index.  Newer versions expose a plain
+        # ``Discrete`` space.  Support both so the wrapper works across versions.
+        if isinstance(self.orig_env.action_space, MultiDiscrete):
+            self._md_env = True
+            self.num_buttons = int(self.orig_env.action_space.nvec[0])
+        elif isinstance(self.orig_env.action_space, Discrete):
+            self._md_env = False
+            self.num_buttons = int(self.orig_env.action_space.n)
+        else:
+            raise TypeError(
+                "Unsupported action_space type: "
+                f"{type(self.orig_env.action_space).__name__}"
+            )
 
         # Expose only Discrete(num_buttons) to the agent
         self.action_space = Discrete(self.num_buttons)
@@ -38,6 +53,9 @@ class KOFActionRepeatEnv(Env):
 
         self.frame_skip = int(frame_skip)
         log("Wrapper initialization complete")
+
+        # Track cumulative reward across episodes for debugging/visualization
+        self.cumulative_reward = 0.0
 
     def reset(self, **kwargs):
         """
@@ -59,7 +77,10 @@ class KOFActionRepeatEnv(Env):
         info_out = {}
 
         for _ in range(self.frame_skip):
-            md_action = np.array([int(action), 1], dtype=np.int64)
+            if self._md_env:
+                md_action = np.array([int(action), 1], dtype=np.int64)
+            else:
+                md_action = int(action)
             out = self.orig_env.step(md_action)
 
             if len(out) == 5:
@@ -80,6 +101,14 @@ class KOFActionRepeatEnv(Env):
 
             if terminated or truncated:
                 break
+
+        # Update running tally and report for visibility when used interactively
+        self.cumulative_reward += total_reward
+        print(
+            f"[KOFActionRepeatEnv] step_reward={total_reward:.2f} "
+            f"total_reward={self.cumulative_reward:.2f}",
+            flush=True,
+        )
 
         # Return exactly 5 values as required by Gymnasium v1.x and RLlib v2.x:
         return last_obs, total_reward, terminated, truncated, info_out


### PR DESCRIPTION
## Summary
- support both `Discrete` and `MultiDiscrete` base environments in `KOFActionRepeatEnv`
- handle action conversion based on base env type
- clarify wrapper docstring
- track cumulative reward across episodes and print it

## Testing
- `python -m py_compile wrappers.py env.py train.py`


------
https://chatgpt.com/codex/tasks/task_e_68523d32b0a0832994f9168fcc9651f9